### PR TITLE
Page routing

### DIFF
--- a/contents/color.html
+++ b/contents/color.html
@@ -3,25 +3,25 @@
   <p>Short description (not mandatory)</p>
   <ul>
     <li>
-      <a data-href="palettes">Palettes</a>
+      <a href="#palettes">Palettes</a>
     </li>
     <li>
-      <a data-href="states">States</a>
+      <a href="#states">States</a>
     </li>
     <li>
-      <a data-href="validations-and-notifications">Validations and notifications</a>
+      <a href="#validations-and-notifications">Validations and notifications</a>
     </li>
     <li>
-      <a data-href="text-and-background-colors">Text and background colors</a>
+      <a href="#text-and-background-colors">Text and background colors</a>
     </li>
     <li>
-      <a data-href="icons">Icons</a>
+      <a href="#icons">Icons</a>
     </li>
     <li>
-      <a data-href="themes">Themes</a>
+      <a href="#themes">Themes</a>
     </li>
     <li>
-      <a data-href="accessibility">Accessibility</a>
+      <a href="#accessibility">Accessibility</a>
     </li>
   </ul>
 </header>

--- a/contents/iconography.html
+++ b/contents/iconography.html
@@ -3,13 +3,13 @@
   <p>Firefox icons are informative, fun and friendly.</p>
   <ul>
     <li>
-      <a class="mr2 blue-5 no-underline pointer" data-href="icon-construction">Icon Construction</a>
+      <a class="mr2 blue-5 no-underline pointer" href="#icon-construction">Icon Construction</a>
     </li>
     <li>
-      <a class="mr2 blue-5 no-underline pointer" data-href="placement">Placement</a>
+      <a class="mr2 blue-5 no-underline pointer" href="#placement">Placement</a>
     </li>
     <li>
-      <a class="mr2 blue-5 no-underline pointer" data-href="accessibility">Accessibility</a>
+      <a class="mr2 blue-5 no-underline pointer" href="#accessibility">Accessibility</a>
     </li>
   </ul>
 </header>
@@ -99,7 +99,7 @@
   <p>
     Preferences and administrator areas in Firefox usually include a dark sidebar navigation. Middle-align both icons and labels.
   </p>
-</section> 
+</section>
 
 <section>
   <h3 id="accessibility">Accesibility</h3>

--- a/contents/index.json
+++ b/contents/index.json
@@ -1,21 +1,21 @@
 [ {"title": "Overview",
     "pages": [
       {"title": "Welcome",
-        "file": "welcome"},
+        "file": "welcome.html"},
       {"title": "Getting started",
-        "file": "getting-started"}
+        "file": "getting-started.html"}
       ]
   },
   {"title": "Style",
     "pages": [
       {"title":"Grid",
-      "file": "grid"},
+      "file": "grid.html"},
       {"title": "Typography",
-      "file": "typography"},
+      "file": "typography.html"},
       {"title": "Color",
-        "file": "color"},
+        "file": "color.html"},
       {"title": "Iconography",
-        "file": "iconography"}
+        "file": "iconography.html"}
       ]
   },
   {"title": "Motion",
@@ -37,7 +37,7 @@
   {"title": "Resources",
     "pages": [
       {"title": "Templates",
-        "file": "templates"}
+        "file": "templates.html"}
       ]
   }
 ]

--- a/contents/welcome.html
+++ b/contents/welcome.html
@@ -1,14 +1,14 @@
 <header>
-  <h1 id="welcome">Welcome</h1>  
+  <h1 id="welcome">Welcome</h1>
   <ul>
     <li>
-      <a data-href="introduction">Introdution</a>
+      <a href="#introduction">Introdution</a>
     </li>
      <li>
-      <a data-href="goals">Goals</a>
+      <a href="#goals">Goals</a>
     </li>
     <li>
-      <a data-href="states">Principles</a>
+      <a href="#principles">Principles</a>
     </li>
   </ul>
 </header>
@@ -32,7 +32,7 @@
     The goal we set for the <em>design system name goes here</em> is to create a modern and faster experience. Our designs should be unified platforms that drive greater efficiency through well-defined and reusable components.
   </p>
 </section>
-  
+
 <section>
   <h2 id="principles">Principles</h2>
   <p>

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "json-loader": "^0.5.4",
     "node-sass": "^3.4.2",
     "react-hot-loader": "^1.3.0",
+    "require-json": "0.0.1",
     "sass-loader": "^3.1.2",
     "style-loader": "^0.13.0",
     "stylelint": "^7.4.2",

--- a/run.js
+++ b/run.js
@@ -4,9 +4,21 @@ var WebpackDevServer = require('webpack-dev-server');
 
 var frontendConfig = require('./webpack.config.js')[0];
 
+var pages = require('./contents/index.json')
+  .map(x => x.pages)
+  .reduce((acc, val) => acc.concat(val), [])
+  .map(x => {
+    return `/${x.file}`
+  });
+
 new WebpackDevServer(webpack(frontendConfig), {
   publicPath: frontendConfig.output.publicPath,
-  hot: true
+  hot: true,
+  proxy: [{
+    context: pages,
+    target: 'http://localhost:3000/index.html',
+    pathRewrite: {'/.*\.html' : ''}
+  }]
 }).listen(3000, 'localhost', function () {});
 
 var app = express();

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -12,7 +12,7 @@ const { createStore, applyMiddleware, combineReducers } = require('redux');
 const { Provider } = require('react-redux');
 const thunkMiddleware = require('redux-thunk');
 const createLogger = require('redux-logger');
-const { createHashHistory } = require('history');
+const { createHistory } = require('history');
 const { syncReduxAndRouter, routeReducer, pushPath } = require('redux-simple-router');
 
 const { getContent, loadUrl } = require('./components/actions.js');
@@ -39,7 +39,7 @@ if (process.env.NODE_ENV === 'development') {
 
 var store = createStoreWithMiddleware(reducer);
 
-var history = createHashHistory({queryKey: false});
+var history = createHistory({queryKey: false});
 syncReduxAndRouter(history, store);
 
 

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -18,12 +18,12 @@ const App = React.createClass({
       <TableOfContents/>
       <article className="order-0 order-1-l overflow-y-scroll-l w-100">
         <Editor/>
-        <footer className="mb5" 
+        <footer className="mb5"
             id="footer"
         >
           <div className="center mw7 ph3 pb3 cf">
             <p className="fl-ns w-50-ns tc tl-ns mt0">
-              <a className="no-underline black" 
+              <a className="no-underline black"
                   href="#!"
               >{'Previos Page Title'}</a>
             </p>

--- a/src/components/actions.js
+++ b/src/components/actions.js
@@ -15,7 +15,12 @@ function getContent(dispatch, file) {
         return `Error loading ${file}`;
       }
       return response.text()
-    }).then(text => dispatch({type: 'TEXT', text: text || '', file: file}));
+    }).then(text => {
+      dispatch({type: 'TEXT', text: text || '', file: file});
+      if (window.location.hash) {
+        window.location.replace(window.location);
+      }
+    });
 }
 
 /**

--- a/src/components/actions.js
+++ b/src/components/actions.js
@@ -9,10 +9,10 @@
 function getContent(dispatch, file) {
   // Put something innocuous in the text to indicate we're loading.
   dispatch({type: 'TEXT', text: '&nbsp;', file: file});
-  return fetch(`contents/${file}.html`)
+  return fetch(`contents/${file}`)
     .then(response => {
       if (response.status < 200 || response.status >= 300) {
-        return `Error loading ${file}.html`;
+        return `Error loading ${file}`;
       }
       return response.text()
     }).then(text => dispatch({type: 'TEXT', text: text || '', file: file}));

--- a/src/components/store.js
+++ b/src/components/store.js
@@ -2,6 +2,7 @@
 
 const {sources, pages} = mungeSources(require('json!../../contents/index.json'));
 const { UPDATE_PATH } = require('redux-simple-router');
+const { parsePath } = require('./utilities.js');
 
 function mungeSources(sources) {
   let pages = []
@@ -20,7 +21,10 @@ function store(state, action) {
   switch (action.type) {
   case "@@router/INIT_PATH":
   case UPDATE_PATH:
-    return Object.assign({}, state, {text: '', file: '', url:''});
+    if (state.file === parsePath(action.payload.path)) {
+      return Object.assign({}, state);
+    }
+    return Object.assign({}, state, {text: '', file: '', url: ''});
   case 'TEXT':
     if (action.text !== '&nbsp;' && action.file !== state.file) {
       // Previous fetch completed, ignore it.

--- a/src/components/utilities.js
+++ b/src/components/utilities.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function parsePath(path) {
-  return path.split('/').concat([null])[1];
+  return path.replace(/#.*/, '').split('/').concat([null])[1];
 }
 
 function getPage(path, pages) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,13 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var failPlugin = require('webpack-fail-plugin');
 var DashboardPlugin = require('webpack-dashboard/plugin');
 
+var pages = require('./contents/index.json')
+  .map(x => x.pages)
+  .reduce((acc, val) => acc.concat(val), [{ file: 'index' }])
+  .map(x => {
+    return { from: 'index.html', to: `../${x.file}` }
+  });
+
 var entry = [
   './src/app.jsx'
 ];
@@ -100,6 +107,7 @@ module.exports = [{
       allChunks: true
     }),
     new CopyWebpackPlugin([
+      ...pages,
       { from: 'index.html', to: '../' },
       { from: 'contents', to: '../contents' },
       { from: 'images', to: '../images' }


### PR DESCRIPTION
- bring back bwinton's strategy of duplicating the index.html file for each url and rerouting to the desired file. 

Fixes: #10

~~note: `npm run serve` does not work with this strategy
also, I think travis is failing because it's trying to deploy from this branch - I don't *think* it's a problem.~~

note: editor stripped whitespace again from any files I changed