### PR TITLE
custom 404 page for github pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Firefox Design System</title>
+    <meta http-equiv="refresh" content="0;URL='/StyleGuide/'" />
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
- add a custom 404 page that just redirects to the home page.
- unable to test as it is Github magic which will select the 404.html page and use it.

- in this case it might be nice to have a notification for the user that they have reach a 404 and have been redirected.
