### PR TITLE
feat: Allow top-level content pages.

### DIFF
--- a/contents/index.json
+++ b/contents/index.json
@@ -1,10 +1,8 @@
-[ {"title": "Overview",
-    "pages": [
-      {"title": "Welcome",
-        "file": "welcome.html"},
-      {"title": "Getting started",
-        "file": "getting-started.html"}
-      ]
+[ {"title": "Welcome",
+    "file": "welcome.html"
+  },
+  {"title": "Getting started",
+    "file": "getting-started.html"
   },
   {"title": "Style",
     "pages": [

--- a/index.html
+++ b/index.html
@@ -24,6 +24,5 @@
     </header>
     <div id="app"></div>
     <script src="static/bundle.js"></script>
-    <script src="scripts/custom.js"></script>
   </body>
 </html>

--- a/run.js
+++ b/run.js
@@ -5,7 +5,7 @@ var WebpackDevServer = require('webpack-dev-server');
 var frontendConfig = require('./webpack.config.js')[0];
 
 var pages = require('./contents/index.json')
-  .map(x => x.pages)
+  .map(x => x.pages || [x])
   .reduce((acc, val) => acc.concat(val), [])
   .map(x => {
     return `/${x.file}`

--- a/src/components/TableOfContents.jsx
+++ b/src/components/TableOfContents.jsx
@@ -25,10 +25,13 @@ const ListItem = connect(state => {
   },
 
   getPage: (item, i) => {
-    return (<Page
-        i={i}
-        item={item}
-            />);
+    return (
+      <Page
+          i={i}
+          item={item}
+          key={i}
+      />
+    );
   },
 
   render() {
@@ -36,6 +39,7 @@ const ListItem = connect(state => {
     let handleClick = () => {
       this.props.handleClick(item);
     }
+    const pages = item.pages || [item];
 
     return (<div className={((page && item.title === page.category) ? ' selected' : '') +
               (this.props.expanded ? ' expanded' : '')}
@@ -43,7 +47,7 @@ const ListItem = connect(state => {
       <p className="fw5 ma0 pv2"
           onClick={handleClick}
       >{item.title}</p>
-      {item.pages.map(this.getPage)}
+      {pages.map(this.getPage)}
     </div>
       );
   }
@@ -109,12 +113,22 @@ const TableOfContents = React.createClass({
     let expanded = this.state.expanded;
 
     let getItem = (item, i) => {
-      return ([].concat(
-        <ListItem expanded={item === expanded}
-            handleClick={handleClick}
+      if (item.pages) {
+        return (
+          <ListItem expanded={item === expanded}
+              handleClick={handleClick}
+              i={i}
+              item={item}
+              key={i}
+          />
+        );
+      }
+      return (
+        <Page
             i={i}
             item={item}
-        />)
+            key={i}
+        />
       );
     }
 

--- a/src/components/store.js
+++ b/src/components/store.js
@@ -7,7 +7,8 @@ const { parsePath } = require('./utilities.js');
 function mungeSources(sources) {
   let pages = []
   sources.forEach(source => {
-    source.pages.forEach(page => {
+    let sourcePages = source.pages || [source];
+    sourcePages.forEach(page => {
       pages.push(Object.assign({'category':source.title}, page));
     })
   })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ var failPlugin = require('webpack-fail-plugin');
 var DashboardPlugin = require('webpack-dashboard/plugin');
 
 var pages = require('./contents/index.json')
-  .map(x => x.pages)
+  .map(x => x.pages || [x])
   .reduce((acc, val) => acc.concat(val), [{ file: 'index' }])
   .map(x => {
     return { from: 'index.html', to: `../${x.file}` }


### PR DESCRIPTION
* To make a page at the top level, just include a `file` key and no `pages` key in the `index.json`
* Note: The links for top-level pages are styled like the other links.  Maybe we (@aminalhazwani) want to change that in a future push. :wink:

Fixes #27.