### PR TITLE
feature: Autogenerate links

### DIFF
--- a/contents/color.html
+++ b/contents/color.html
@@ -1,31 +1,7 @@
 <header>
   <h1>Colors</h1>
   <p>Short description (not mandatory)</p>
-  <ul>
-    <li>
-      <a href="#palettes">Palettes</a>
-    </li>
-    <li>
-      <a href="#states">States</a>
-    </li>
-    <li>
-      <a href="#validations-and-notifications">Validations and notifications</a>
-    </li>
-    <li>
-      <a href="#text-and-background-colors">Text and background colors</a>
-    </li>
-    <li>
-      <a href="#icons">Icons</a>
-    </li>
-    <li>
-      <a href="#themes">Themes</a>
-    </li>
-    <li>
-      <a href="#accessibility">Accessibility</a>
-    </li>
-  </ul>
 </header>
-
 
 <section>
   <h2>Palettes</h2>
@@ -426,7 +402,7 @@
 <section>
   <h2>Text and background colors</h2>
   <p>
-    Texts are set with an alpha channel in order to make them flexible enough to work on different backgrounds. 
+    Texts are set with an alpha channel in order to make them flexible enough to work on different backgrounds.
   </p>
   <h3>Dark text on light background</h3>
   <table>

--- a/contents/iconography.html
+++ b/contents/iconography.html
@@ -1,17 +1,6 @@
 <header>
   <h1>Iconography</h1>
   <p>Firefox icons are informative, fun and friendly.</p>
-  <ul>
-    <li>
-      <a href="#icon-construction">Icon Construction</a>
-    </li>
-    <li>
-      <a href="#placement">Placement</a>
-    </li>
-    <li>
-      <a href="#accessibility">Accessibility</a>
-    </li>
-  </ul>
 </header>
 
 <section>

--- a/contents/welcome.html
+++ b/contents/welcome.html
@@ -1,16 +1,5 @@
 <header>
   <h1>Welcome</h1>
-  <ul>
-    <li>
-      <a href="#introduction">Introdution</a>
-    </li>
-     <li>
-      <a href="#goals">Goals</a>
-    </li>
-    <li>
-      <a href="#principles">Principles</a>
-    </li>
-  </ul>
 </header>
 
 <section>

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,8 +1,10 @@
 const React = require('react');
+const ReactDOM = require('react-dom');
 
 const TableOfContents = React.createFactory(require('./TableOfContents.jsx'));
 const Editor = React.createFactory(require('./Editor.jsx'));
 const Footer = React.createFactory(require('./Footer.jsx'));
+const Header = React.createFactory(require('./Header.jsx'));
 
 const { connect } = require('react-redux');
 const { getPage } = require('./utilities.js');
@@ -13,12 +15,46 @@ const App = React.createClass({
     dispatch: React.PropTypes.func,
     page: React.PropTypes.shape()
   },
+  getInitialState : function() {
+    return {header_links: [], header: '', header_description: ''};
+  },
+
+  addIds: function (editor_page) {
+    let node = ReactDOM.findDOMNode(editor_page);
+    let headings = Array.from(node.querySelectorAll('h1,h2,h3,h4'));
+    let header_links = [];
+    let header, header_description;
+    if (node.querySelector('header')) {
+      header = node.querySelector('header h1').textContent;
+      header_description = node.querySelector('header p') ? node.querySelector('header p').textContent : '';
+      node.removeChild(node.querySelector('header'));
+    }
+    headings.forEach(e => {
+      if (!e.id) {
+        e.id = e.textContent.toLowerCase().replace(/ /g, '-');
+      }
+      if (e.tagName === 'H2') {
+        header_links.push({name: e.textContent, id: e.id})
+      }
+    });
+
+    let setState = this.setState.bind(this);
+    setState({
+      header: header || '',
+      header_description: header_description || '',
+      header_links: header_links
+    });
+  },
 
   render: function() {
     return (<div className="flex flex-column flex-row-l fixed-l w-100-l h-100-l">
       <TableOfContents/>
       <article className="order-0 order-1-l overflow-y-scroll-l w-100">
-        <Editor/>
+        <Header header = {this.state.header}
+            header_description = {this.state.header_description}
+            header_links = {this.state.header_links}
+        />
+        <Editor addIds = {this.addIds}/>
         <Footer/>
       </article>
     </div>);

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,5 +1,4 @@
 const React = require('react');
-const ReactDOM = require('react-dom');
 
 const TableOfContents = React.createFactory(require('./TableOfContents.jsx'));
 const Editor = React.createFactory(require('./Editor.jsx'));
@@ -15,46 +14,13 @@ const App = React.createClass({
     dispatch: React.PropTypes.func,
     page: React.PropTypes.shape()
   },
-  getInitialState : function() {
-    return {header_links: [], header: '', header_description: ''};
-  },
-
-  addIds: function (editor_page) {
-    let node = ReactDOM.findDOMNode(editor_page);
-    let headings = Array.from(node.querySelectorAll('h1,h2,h3,h4'));
-    let header_links = [];
-    let header, header_description;
-    if (node.querySelector('header')) {
-      header = node.querySelector('header h1').textContent;
-      header_description = node.querySelector('header p') ? node.querySelector('header p').textContent : '';
-      node.removeChild(node.querySelector('header'));
-    }
-    headings.forEach(e => {
-      if (!e.id) {
-        e.id = e.textContent.toLowerCase().replace(/ /g, '-');
-      }
-      if (e.tagName === 'H2') {
-        header_links.push({name: e.textContent, id: e.id})
-      }
-    });
-
-    let setState = this.setState.bind(this);
-    setState({
-      header: header || '',
-      header_description: header_description || '',
-      header_links: header_links
-    });
-  },
 
   render: function() {
     return (<div className="flex flex-column flex-row-l fixed-l w-100-l h-100-l">
       <TableOfContents/>
       <article className="order-0 order-1-l overflow-y-scroll-l w-100">
-        <Header header = {this.state.header}
-            header_description = {this.state.header_description}
-            header_links = {this.state.header_links}
-        />
-        <Editor addIds = {this.addIds}/>
+        <Header/>
+        <Editor/>
         <Footer/>
       </article>
     </div>);

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -8,6 +8,7 @@ require('../../node_modules/highlight.js/styles/color-brewer.css');
 const React = require('react');
 const { connect } = require('react-redux');
 const ReactDOM = require('react-dom');
+const { updateHeader } = require('./actions.js');
 
 const Editor = React.createClass({
   displayName: 'Editor',
@@ -43,27 +44,26 @@ const Editor = React.createClass({
     let node = ReactDOM.findDOMNode(this);
     let headings = Array.from(node.querySelectorAll('h1,h2,h3,h4'));
     let header_links = [];
-    let header, header_description;
+    let header = '';
+    let header_description = '';
     if (node.querySelector('header')) {
-      header = node.querySelector('header h1').textContent;
-      header_description = node.querySelector('header p') ? node.querySelector('header p').textContent : '';
+      header = node.querySelector('header h1').textContent.trim();
+      header_description = node.querySelector('header p') ? node.querySelector('header p').textContent.trim() : '';
       node.removeChild(node.querySelector('header'));
     }
     headings.forEach(e => {
       if (!e.id) {
-        e.id = e.textContent.toLowerCase().replace(/ /g, '-');
+        e.id = e.textContent.trim().toLowerCase().replace(/ /g, '-');
       }
       if (e.tagName === 'H2') {
-        header_links.push({name: e.textContent, id: e.id})
+        header_links.push({name: e.textContent.trim(), id: e.id});
       }
     });
-
-    this.props.dispatch({type: 'UPDATE_IDS', header: header, header_description: header_description, header_links: header_links});
+    updateHeader(this.props.dispatch, {header: header, header_description: header_description, header_links: header_links});
   },
 
   render: function() {
-    let text = this.props.text;
-    let url = this.props.url;
+    let {text, url} = this.props;
     if (url) {
       if (process.env.NODE_ENV === 'development') {
         url = `https://firefoxux.github.io${url}`;
@@ -71,11 +71,10 @@ const Editor = React.createClass({
       text = `<iframe src=${url} id="editor-iframe" frameborder="0"></iframe>`;
     }
     return (<div className={'center mb5 mw7 pb3 ph3 mt3 mt0-l' +
-      (this.props.url ? ' url' : ' ')}
+      (url ? ' url' : ' ')}
         dangerouslySetInnerHTML={{__html:
           '<div class="popup"></div>' + text}}
-            >
-            </div>)
+            ></div>)
   }
 
 });

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -7,11 +7,11 @@ require('../../node_modules/highlight.js/styles/color-brewer.css');
 
 const React = require('react');
 const { connect } = require('react-redux');
+const ReactDOM = require('react-dom');
 
 const Editor = React.createClass({
   displayName: 'Editor',
   propTypes: {
-    addIds: React.PropTypes.func,
     dispatch: React.PropTypes.func,
     text: React.PropTypes.string,
     url: React.PropTypes.string
@@ -31,13 +31,34 @@ const Editor = React.createClass({
         }
       }
     }, false);
-
   },
 
   componentDidUpdate: function(prevProps) {
     if (prevProps.text !== this.props.text) {
-      this.props.addIds(this)
+      this.addIds();
     }
+  },
+
+  addIds: function () {
+    let node = ReactDOM.findDOMNode(this);
+    let headings = Array.from(node.querySelectorAll('h1,h2,h3,h4'));
+    let header_links = [];
+    let header, header_description;
+    if (node.querySelector('header')) {
+      header = node.querySelector('header h1').textContent;
+      header_description = node.querySelector('header p') ? node.querySelector('header p').textContent : '';
+      node.removeChild(node.querySelector('header'));
+    }
+    headings.forEach(e => {
+      if (!e.id) {
+        e.id = e.textContent.toLowerCase().replace(/ /g, '-');
+      }
+      if (e.tagName === 'H2') {
+        header_links.push({name: e.textContent, id: e.id})
+      }
+    });
+
+    this.props.dispatch({type: 'UPDATE_IDS', header: header, header_description: header_description, header_links: header_links});
   },
 
   render: function() {

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -6,22 +6,12 @@
 require('../../node_modules/highlight.js/styles/color-brewer.css');
 
 const React = require('react');
-const ReactDOM = require('react-dom');
 const { connect } = require('react-redux');
-
-function addIds(node) {
-  let headings = Array.from(node.querySelectorAll('h1,h2,h3,h4'));
-
-  headings.forEach(e => {
-    if (!e.id) {
-      e.id = e.textContent.toLowerCase().replace(/ /g, '-');
-    }
-  });
-}
 
 const Editor = React.createClass({
   displayName: 'Editor',
   propTypes: {
+    addIds: React.PropTypes.func,
     dispatch: React.PropTypes.func,
     text: React.PropTypes.string,
     url: React.PropTypes.string
@@ -46,7 +36,7 @@ const Editor = React.createClass({
 
   componentDidUpdate: function(prevProps) {
     if (prevProps.text !== this.props.text) {
-      addIds(ReactDOM.findDOMNode(this));
+      this.props.addIds(this)
     }
   },
 
@@ -59,11 +49,12 @@ const Editor = React.createClass({
       }
       text = `<iframe src=${url} id="editor-iframe" frameborder="0"></iframe>`;
     }
-    return (<div className={'center mb5 mw7 pb3 ph3 mt3 pt5 mt0-l pt4-l' +
+    return (<div className={'center mb5 mw7 pb3 ph3 mt3 mt0-l' +
       (this.props.url ? ' url' : ' ')}
         dangerouslySetInnerHTML={{__html:
           '<div class="popup"></div>' + text}}
-            ></div>)
+            >
+            </div>)
   }
 
 });

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -10,36 +10,28 @@ const Header = React.createClass({
   },
 
   render: function() {
-    let links = this.props.header_links.map((link, i) => {
+    const {header_links, header, header_description} = this.props;
+    let links = header_links.map((link, i) => {
       return (<li
           key={i}
               ><a href={'#' + link.id}>
               {link.name}</a>
       </li>);
     });
+    let header_id = header.trim().toLowerCase().replace(/ /g, '-');
 
-    var header_id = this.props.header.toLowerCase().replace(/ /g, '-');
     return(
       <header className = "center mb5 mw7 ph3 mt3 mt0-l pt4-l">
-        <h1 id={header_id}>{this.props.header}</h1>
-        <p>{this.props.header_description}</p>
-        <ul>
-          {links}
-        </ul>
+        <h1 id={header_id}>{header}</h1>
+        <p>{header_description}</p>
+        <ul>{links}</ul>
       </header>)
   }
 });
 
-// module.exports = Header;
-
 function makeProps(state) {
-  var {header, header_description, header_links} = state.data;
-
-  return {
-    header: header,
-    header_description: header_description,
-    header_links: header_links
-  }
+  let {header, header_description, header_links} = state.data;
+  return {header, header_description, header_links};
 }
 
 module.exports = connect(makeProps)(Header);

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,5 @@
 const React = require('react');
+const { connect } = require('react-redux');
 
 const Header = React.createClass({
   displayName: 'Header',
@@ -29,4 +30,16 @@ const Header = React.createClass({
   }
 });
 
-module.exports = Header;
+// module.exports = Header;
+
+function makeProps(state) {
+  var {header, header_description, header_links} = state.data;
+
+  return {
+    header: header,
+    header_description: header_description,
+    header_links: header_links
+  }
+}
+
+module.exports = connect(makeProps)(Header);

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,32 @@
+const React = require('react');
+
+const Header = React.createClass({
+  displayName: 'Header',
+  propTypes: {
+    header: React.PropTypes.string,
+    header_description: React.PropTypes.string,
+    header_links: React.PropTypes.arrayOf(React.PropTypes.shape())
+  },
+
+  render: function() {
+    let links = this.props.header_links.map((link, i) => {
+      return (<li
+          key={i}
+              ><a href={'#' + link.id}>
+              {link.name}</a>
+      </li>);
+    });
+
+    var header_id = this.props.header.toLowerCase().replace(/ /g, '-');
+    return(
+      <header className = "center mb5 mw7 ph3 mt3 mt0-l pt4-l">
+        <h1 id={header_id}>{this.props.header}</h1>
+        <p>{this.props.header_description}</p>
+        <ul>
+          {links}
+        </ul>
+      </header>)
+  }
+});
+
+module.exports = Header;

--- a/src/components/TableOfContents.jsx
+++ b/src/components/TableOfContents.jsx
@@ -138,14 +138,14 @@ const TableOfContents = React.createClass({
 
     let items = sources.map(getItem);
 
-    return (<nav 
+    return (<nav
         className="bg-near-white h-100 w-100 z-max order-1 order-0-l w-6-l"
         id="nav"
             >
       <div className="flex flex-column h-100 center mw7 pt3 ph3 pt4-l ph4-l overflow-y-scroll">
         <div className="self-start dn db-l">
           <p className="f4 fw5 lh-solid ma0">
-            <a className="near-black no-underline" 
+            <a className="near-black no-underline"
                 href="/StyleGuide/welcome.html"
             >{'Firefox Design System'}
             </a>
@@ -158,7 +158,7 @@ const TableOfContents = React.createClass({
         <div className="self-end w-100 pb3 pb4-l">
           <p className="lh-copy ma0 fw4">
             {'Questions, doubts or feedback? '}
-            <a className="near-black no-underline fw5" 
+            <a className="near-black no-underline fw5"
                 href="https://github.com/bwinton/StyleGuide/issues"
             >{'Open an issue on GitHub!'}
             </a>

--- a/src/components/actions.js
+++ b/src/components/actions.js
@@ -34,7 +34,19 @@ function loadUrl(dispatch, url) {
   dispatch({type: 'URL', url: url});
 }
 
+/**
+ * Get header title, links and description, and notify the store.
+ *
+ * @param {function} dispatch - The Redux dispatcher.
+ * @param {Object} header_content - An Object containing the header content.
+ */
+
+function updateHeader(dispatch, header_content){
+  dispatch(Object.assign({}, {type: 'UPDATE_HEADER'}, header_content));
+}
+
 module.exports = {
   getContent: getContent,
-  loadUrl: loadUrl
+  loadUrl: loadUrl,
+  updateHeader: updateHeader
 };

--- a/src/components/store.js
+++ b/src/components/store.js
@@ -17,7 +17,15 @@ function mungeSources(sources) {
 
 function store(state, action) {
   if (!state) {
-    state = { sources: sources, pages: pages, text: '', file: '', url:'' };
+    state = {
+      sources: sources,
+      pages: pages,
+      text: '',
+      file: '',
+      url: '',
+      header: '',
+      header_description: '',
+      header_links: [] };
   }
   switch (action.type) {
   case "@@router/INIT_PATH":
@@ -34,6 +42,8 @@ function store(state, action) {
     return Object.assign({}, state, {text: action.text || '', file: action.file});
   case 'URL':
     return Object.assign({}, state, {url: action.url || ''});
+  case 'UPDATE_IDS':
+    return Object.assign({}, state, {header: action.header || '', header_description: action.header_description || '', header_links: action.header_links});
   default:
     return state;
   }

--- a/src/components/store.js
+++ b/src/components/store.js
@@ -42,7 +42,7 @@ function store(state, action) {
     return Object.assign({}, state, {text: action.text || '', file: action.file});
   case 'URL':
     return Object.assign({}, state, {url: action.url || ''});
-  case 'UPDATE_IDS':
+  case 'UPDATE_HEADER':
     return Object.assign({}, state, {header: action.header || '', header_description: action.header_description || '', header_links: action.header_links});
   default:
     return state;


### PR DESCRIPTION
- move the `addIds` fn to `App.js` so that after getting the page from editor we can pass props down to the Header.

- remove all the manually created links in the html files.

- one thing I'm not happy about is setting the <App> state. Because using redux we should not do that (I noticed we are also doing it in the table of contents). We should be setting the store state from the Editor then having that be reached from the Header. I can rewrite both of these.

Fixes: #23. 